### PR TITLE
fix: call `mdc:configSources` after all modules have run

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -123,14 +123,12 @@ export default defineNuxtModule<ModuleOptions>({
       }
     }
 
-    nuxt.hook('modules:done', async () => {
-      await nuxt.callHook('mdc:configSources', mdcConfigs)
+    nuxt.hook('modules:done', () => nuxt.callHook('mdc:configSources', mdcConfigs))
 
-      registerTemplate({
-        filename: 'mdc-configs.mjs',
-        getContents: templates.mdcConfigs,
-        options: { configs: mdcConfigs },
-      })
+    registerTemplate({
+      filename: 'mdc-configs.mjs',
+      getContents: templates.mdcConfigs,
+      options: { configs: mdcConfigs },
     })
 
     // Add highlighter


### PR DESCRIPTION
otherwise modules have to ensure they run before this module

(in general modules should only call custom hooks after `modules:done` unless they do not wish to be extended by other modules)