### PR TITLE
fix: skip unresolved Vite optimize deps

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -210,20 +210,21 @@ export default defineNuxtModule<ModuleOptions>({
       },
     })
 
+    const viteOptimizeDepsInclude = await resolveViteOptimizeDeps(createResolver(nuxt.options.rootDir), [
+      'remark-gfm', // from runtime/parser/index.ts
+      'remark-emoji', // from runtime/parser/index.ts
+      'remark-mdc', // from runtime/parser/index.ts
+      'remark-rehype', // from runtime/parser/index.ts
+      'rehype-raw', // from runtime/parser/index.ts
+      'parse5', // transitive deps of rehype
+      'unist-util-visit', // from runtime/highlighter/rehype.ts
+      'unified', // deps by all the plugins
+      'debug', // deps by many libraries but it's not an ESM
+      'extend', // transitive dep of unified, CJS-only
+    ])
+
     // Update Vite optimizeDeps
     extendViteConfig((config) => {
-      const include = [
-        'remark-gfm', // from runtime/parser/index.ts
-        'remark-emoji', // from runtime/parser/index.ts
-        'remark-mdc', // from runtime/parser/index.ts
-        'remark-rehype', // from runtime/parser/index.ts
-        'rehype-raw', // from runtime/parser/index.ts
-        'parse5', // transitive deps of rehype
-        'unist-util-visit', // from runtime/highlighter/rehype.ts
-        'unified', // deps by all the plugins
-        'debug', // deps by many libraries but it's not an ESM
-        'extend', // transitive dep of unified, CJS-only
-      ]
       const exclude = [
         '@nuxtjs/mdc', // package itself, it's a build time module
       ]
@@ -231,7 +232,7 @@ export default defineNuxtModule<ModuleOptions>({
       config.optimizeDeps.exclude ||= []
       config.optimizeDeps.include ||= []
 
-      for (const pkg of include) {
+      for (const pkg of viteOptimizeDepsInclude) {
         if (!config.optimizeDeps.include.includes(pkg)) {
           config.optimizeDeps.include.push('@nuxtjs/mdc > ' + pkg)
         }
@@ -281,6 +282,22 @@ function resolveOptions(options: ModuleOptions) {
       options.highlight.langs.push(...options.highlight.preload as any || [])
     }
   }
+}
+
+async function resolveViteOptimizeDeps(resolver: ReturnType<typeof createResolver>, deps: string[]) {
+  const resolvedDeps: string[] = []
+
+  for (const dep of deps) {
+    try {
+      await resolver.resolvePath(dep)
+      resolvedDeps.push(dep)
+    }
+    catch {
+      // Skip unresolved optional/transitive deps to avoid Vite optimizeDeps warnings.
+    }
+  }
+
+  return resolvedDeps
 }
 
 declare module '@nuxt/schema' {


### PR DESCRIPTION
Fixes Vite `optimizeDeps.include` warnings/errors under pnpm by only adding MDC-related dependencies when they can be resolved from the Nuxt app context.

This PR is related to #174 and #438. I encountered the same issue described in #438, where Nuxt Content uses MDC to parse Markdown, but some remark/rehype/unified dependencies are not exposed at the project root with pnpm's default dependency layout. As a result, Vite can fail to resolve pre-optimized dependencies during dev mode.

Tested environment:

- Nuxt: 4.4.6
- Vue: 3.5.34
- @nuxt/content: 3.14.0
- @nuxtjs/mdc: 0.22.0
- Package manager: pnpm
- OS: Windows
- Node.js: 24.15.0