### PR TITLE
fix: validate xlink:href and fix data:text/html prefix check in sanitizer

### DIFF
--- a/src/runtime/parser/utils/props.ts
+++ b/src/runtime/parser/utils/props.ts
@@ -30,7 +30,7 @@ function isAnchorLinkAllowed(value: string) {
       return true
     }
 
-    if (unsafeLinkPrefix.some(prefix => url.protocol.toLowerCase().startsWith(prefix))) {
+    if (unsafeLinkPrefix.some(prefix => url.href.toLowerCase().startsWith(prefix))) {
       return false
     }
   }
@@ -47,7 +47,7 @@ export const validateProp = (attribute: string, value: string) => {
     return false
   }
 
-  if (attribute === 'href' || attribute === 'src') {
+  if (attribute === 'href' || attribute === 'src' || attribute === 'xlinkhref') {
     return isAnchorLinkAllowed(value)
   }
 

--- a/test/markdown/xss.test.ts
+++ b/test/markdown/xss.test.ts
@@ -1,6 +1,6 @@
 import { expect, it } from 'vitest'
 import { parseMarkdown } from '../utils/parser'
-import type { MDCElement, MDCNode } from '../../src/types'
+import type { MDCElement } from '../../src/types'
 import { validateProp } from '../../src/runtime/parser/utils/props'
 
 const md = `\
@@ -98,7 +98,7 @@ it('should block data:text/html on anchor href', async () => {
 `.trim())
 
   const p = body.children[0] as MDCElement
-  const a = (p.children?.[0] as MDCElement)
+  const a = p.children?.[0] as MDCElement
   expect(a.props?.href).toBeUndefined()
 })
 

--- a/test/markdown/xss.test.ts
+++ b/test/markdown/xss.test.ts
@@ -1,6 +1,6 @@
 import { expect, it } from 'vitest'
 import { parseMarkdown } from '../utils/parser'
-import type { MDCElement } from '../../src/types'
+import type { MDCElement, MDCNode } from '../../src/types'
 import { validateProp } from '../../src/runtime/parser/utils/props'
 
 const md = `\
@@ -67,4 +67,44 @@ it('XSS payloads with HTML entities should be caught', async () => {
       expect(Object.keys(props)).toHaveLength(0)
     }
   }
+})
+
+it('should block xlink:href on SVG anchor elements', async () => {
+  const { body } = await parseMarkdown(`\
+<svg viewBox="0 0 10 10">
+  <a xlink:href="javascript:alert(1)">click</a>
+</svg>
+`.trim())
+
+  const svg = body.children[0] as MDCElement
+  const a = svg.children?.find((c): c is MDCElement => (c as MDCElement).tag === 'a')
+
+  expect(a).toBeDefined()
+  expect((a as MDCElement).props?.xLinkHref).toBeUndefined()
+})
+
+it('should block data:text/html on iframe src', async () => {
+  const { body } = await parseMarkdown(`\
+<iframe src="data:text/html,<script>alert(1)</script>"></iframe>
+`.trim())
+
+  const iframe = body.children[0] as MDCElement
+  expect(iframe.props?.src).toBeUndefined()
+})
+
+it('should block data:text/html on anchor href', async () => {
+  const { body } = await parseMarkdown(`\
+<a href="data:text/html,<script>alert(1)</script>">click</a>
+`.trim())
+
+  const p = body.children[0] as MDCElement
+  const a = (p.children?.[0] as MDCElement)
+  expect(a.props?.href).toBeUndefined()
+})
+
+it('should allow safe xlink:href values', async () => {
+  expect(validateProp('xlinkhref', 'https://example.com')).toBe(true)
+  expect(validateProp('xLinkHref', 'https://example.com')).toBe(true)
+  expect(validateProp('xlink:href', 'https://example.com')).toBe(true)
+  expect(validateProp('xlinkhref', '/relative/path')).toBe(true)
 })


### PR DESCRIPTION
Two bypasses in the HTML sanitizer:

1. SVG xlink:href not validated - xlinkhref was not checked like href/src in validateProp
2. data:text/html deny-list entries were dead code - compared against url.protocol which is always data: for data URIs

Fixed: check xlinkhref in validateProp, compare url.href instead of url.protocol.

All 54 existing tests pass. Added 4 new regression tests.