### PR TITLE
fix: vite 8 alias resolution supression

### DIFF
--- a/src/runtime/parser/index.ts
+++ b/src/runtime/parser/index.ts
@@ -16,10 +16,18 @@ let generatedMdcConfigs: MdcConfig[] | undefined
 
 export const createParseProcessor = async (inlineOptions: MDCParseOptions = {}) => {
   if (!moduleOptions) {
-    moduleOptions = await import('#mdc-imports' /* @vite-ignore */).catch(() => ({}))
+    // `#mdc-imports` / `#mdc-configs` resolve to the Nuxt-generated templates via the module's
+    // registered Vite/Nitro aliases. The `.catch()` is the fallback for environments where they are
+    // not registered (standalone / plain Node), where the import simply rejects.
+    //
+    // Do NOT re-add `/* @vite-ignore */` here. Under Vite 8 it suppresses alias resolution, so the
+    // bare `#mdc-imports` specifier is shipped to the client where it fails at runtime with
+    // "Failed to resolve module specifier" and dispatches a `vite:preloadError`. (Vite 7 resolved
+    // the alias even with the ignore comment, which is why this only regressed on Vite 8.)
+    moduleOptions = await import('#mdc-imports').catch(() => ({}))
   }
   if (!generatedMdcConfigs) {
-    generatedMdcConfigs = await import('#mdc-configs' /* @vite-ignore */)
+    generatedMdcConfigs = await import('#mdc-configs')
       .then(r => r.getMdcConfigs())
       .catch(() => ([]))
   }


### PR DESCRIPTION
Removes `/* @vite-ignore */` from the `#mdc-imports` / `#mdc-configs` dynamic imports in `runtime/parser/index.ts` so they resolve via the module's registered aliases on the client. Fixes #500.

---

**Reproduction**: https://github.com/adamdehaven/emit-route-chunk-error-reproduction

The patched build tarball is available to see the fix in the reproduction as well

---


`createParseProcessor` runs on the client and does:

```ts
await import('#mdc-imports' /* @vite-ignore */).catch(() => ({}))
await import('#mdc-configs' /* @vite-ignore */).then(r => r.getMdcConfigs()).catch(() => [])
```

`#mdc-imports` / `#mdc-configs` are registered Vite/Nitro aliases. Under Vite 7 they resolved despite the `@vite-ignore` hint; under Vite 8 (Nuxt 4.5+) the hint is honored and the bare specifier is shipped to the browser, where it rejects with `Failed to resolve module specifier` and dispatches a `vite:preloadError` on every client-side parse. That event is consequential downstream (e.g. `experimental.emitRouteChunkError: 'automatic-immediate'` reloads the whole app on it, turning client navigations into full-page reloads).

This PR drops the `@vite-ignore` comment so Vite resolves the aliases on both Vite 7 and 8. The `.catch()` fallbacks are kept for environments where the aliases aren't registered.

## Testing

- `pnpm test`: 63/63 pass.
- Verified in a minimal Nuxt app: on Vite 8 the client no longer emits the `vite:preloadError` (Failed to resolve module specifier '#mdc-imports'); Vite 7 unchanged.
- Standalone/Node usage is unchanged (the import rejects and falls back via `.catch()`).

## Notes

- Standalone/Node usage is unchanged (the import rejects and falls back via `.catch()`).
- A non-Nuxt bundler build that imports the parser already fails to resolve `#mdc-imports` with or without this change (identical Rollup failed to resolve import error), so this PR does not regress that path, it only fixes the Vite 8 Nuxt regression. 