### PR TITLE
fix(MDCRenderer): keep async component identity stable across renders

### DIFF
--- a/src/runtime/components/MDCRenderer.vue
+++ b/src/runtime/components/MDCRenderer.vue
@@ -3,7 +3,7 @@ import { h, resolveComponent as vueResolveComponent, reactive, watch, Text, Comm
 import destr from 'destr'
 import { kebabCase, pascalCase } from 'scule'
 import { find, html } from 'property-information'
-import type { VNode, ConcreteComponent, PropType, DefineComponent } from 'vue'
+import type { VNode, ConcreteComponent, PropType, DefineComponent, Component } from 'vue'
 import type { MDCElement, MDCNode, MDCRoot, MDCData, MDCRenderOptions } from '@nuxtjs/mdc'
 import htmlTags from '../parser/utils/html-tags-list'
 import { flatUnwrap, nodeTextContent } from '../utils/node'
@@ -402,6 +402,10 @@ function propsToDataRxBind(key: string, value: any, data: any, documentMeta: MDC
   return data
 }
 
+// `defineAsyncComponent` returns a new component type on every call, and this runs from the
+// render function. Caching keeps the type identity stable so Vue patches instead of remounting.
+const asyncWrappedComponents = new WeakMap<object, Component>()
+
 /**
  * Resolve component if it's a Vue component
  */
@@ -422,7 +426,12 @@ const resolveComponentInstance = (component: any) => {
     }
 
     if ('setup' in _component) {
-      return defineAsyncComponent(() => new Promise(resolve => resolve(_component)))
+      let asyncComponent = asyncWrappedComponents.get(_component)
+      if (!asyncComponent) {
+        asyncComponent = defineAsyncComponent(() => new Promise(resolve => resolve(_component)))
+        asyncWrappedComponents.set(_component, asyncComponent)
+      }
+      return asyncComponent
     }
 
     return _component


### PR DESCRIPTION
### 🔗 Linked issue

Ref nuxt-content/nuxt-studio#383

### 📚 Description

`defineAsyncComponent` returns a **new component type** on every call, and `resolveComponentInstance` calls it from inside the render path:

```js
if ('setup' in _component) {
  return defineAsyncComponent(() => new Promise(resolve => resolve(_component)))
}
```

`resolveComponentInstance` is passed straight into `_renderSlots` as `resolveComponent` and invoked per node on every render, so any component reaching this branch gets a different type on each pass. Vue can't patch across a type change — it unmounts and remounts the node, and the async wrapper renders nothing for a tick while it re-resolves.

Caching the wrapper in a `WeakMap` keyed by the resolved component keeps the type identity stable, so repeated renders patch instead of remount. Sharing one wrapper across usages is what a plain component import already does — the wrapper holds no per-instance state.

In practice most Nuxt setups take the `AsyncComponentWrapper` early-return above this branch and never reach it, so this is mostly latent there; it's more likely to bite standalone MDC users. The companion fix for the path that does fire under Nuxt Content is nuxt/content#3835.

Found while tracking down nuxt-content/nuxt-studio#383, where Studio's live preview remounts the whole rendered document on every keystroke.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have added tests (none — component-identity fix with no observable output change; existing suite passes, 63/63).
